### PR TITLE
test: uid プラグインの ID 生成ロジックにユニットテストを追加

### DIFF
--- a/apps/uid/package.json
+++ b/apps/uid/package.json
@@ -10,7 +10,8 @@
     "build:js": "plugin build",
     "build": "pnpm run build:js && concurrently \"pnpm:build:css-*\" && plugin zip",
     "standalone": "pnpm run build && plugin zip --env standalone",
-    "dev": "plugin dev --cert-dir ~/config/cert"
+    "dev": "plugin dev --cert-dir ~/config/cert",
+    "test": "vitest run"
   },
   "browser": {
     "path": false
@@ -61,6 +62,7 @@
     "concurrently": "^9.2.1",
     "dotenv": "^17.4.2",
     "ts-loader": "^9.5.7",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/uid/src/lib/utils.test.ts
+++ b/apps/uid/src/lib/utils.test.ts
@@ -1,0 +1,142 @@
+import type { kintoneAPI } from '@konomi-app/kintone-utilities';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { PluginCondition } from './plugin';
+import { cn, getId, getRandomValue } from './utils';
+
+/**
+ * `getId` が参照するのは `mode` と `customIDRules` のみのため、
+ * テストではその2つに絞った最小限の `PluginCondition` を生成する。
+ */
+const buildCondition = (mode: string, customIDRules: unknown[] = []): PluginCondition =>
+  ({ mode, customIDRules }) as unknown as PluginCondition;
+
+/** テスト用の単一行テキストフィールドを生成するヘルパー。 */
+const textField = (value: string): kintoneAPI.Field =>
+  ({ type: 'SINGLE_LINE_TEXT', value }) as unknown as kintoneAPI.Field;
+
+/** テスト用のレコードデータを生成するヘルパー。 */
+const buildRecord = (fields: Record<string, kintoneAPI.Field>): kintoneAPI.RecordData =>
+  fields as unknown as kintoneAPI.RecordData;
+
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getRandomValue', () => {
+  test('base36（数字と英小文字）のみで構成された文字列を返す', () => {
+    expect(getRandomValue()).toMatch(/^[0-9a-z]*$/);
+  });
+
+  test('Math.random の戻り値に基づいた値を生成する', () => {
+    // (0.5).toString(36) === '0.i' なので、slice(2) は 'i' になる
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    expect(getRandomValue()).toBe('i');
+  });
+
+  test('呼び出しごとに異なる値を生成する', () => {
+    expect(getRandomValue()).not.toBe(getRandomValue());
+  });
+});
+
+describe('getId - 単純なモード', () => {
+  test('nanoid モードでは空でない文字列を返す', () => {
+    const id = getId({ condition: buildCondition('nanoid'), record: buildRecord({}) });
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  test('uuid モードでは UUID v4 形式の文字列を返す', () => {
+    const id = getId({ condition: buildCondition('uuid'), record: buildRecord({}) });
+    expect(id).toMatch(UUID_V4_PATTERN);
+  });
+
+  test('random モードでは Math.random に基づいた値を返す', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const id = getId({ condition: buildCondition('random'), record: buildRecord({}) });
+    expect(id).toBe('i');
+  });
+
+  test('未知のモードの場合は例外を投げる', () => {
+    expect(() =>
+      getId({ condition: buildCondition('unknown-mode'), record: buildRecord({}) })
+    ).toThrow('Unknown mode: unknown-mode');
+  });
+});
+
+describe('getId - custom モード', () => {
+  test('constant ルールは prefix と value を連結する', () => {
+    const condition = buildCondition('custom', [
+      { id: 'r1', type: 'constant', prefix: 'PRE-', value: 'ABC' },
+    ]);
+    expect(getId({ condition, record: buildRecord({}) })).toBe('PRE-ABC');
+  });
+
+  test('複数のルールを定義順に連結する', () => {
+    const condition = buildCondition('custom', [
+      { id: 'r1', type: 'constant', prefix: 'A', value: '1' },
+      { id: 'r2', type: 'constant', prefix: 'B', value: '2' },
+    ]);
+    expect(getId({ condition, record: buildRecord({}) })).toBe('A1B2');
+  });
+
+  test('field_value ルールは対象フィールドの値を使用する', () => {
+    const condition = buildCondition('custom', [
+      { id: 'r1', type: 'field_value', prefix: '', fieldCode: 'name', format: '' },
+    ]);
+    const record = buildRecord({ name: textField('hello') });
+    expect(getId({ condition, record })).toBe('hello');
+  });
+
+  test('field_value ルールは prefix とフィールド値を連結する', () => {
+    const condition = buildCondition('custom', [
+      { id: 'r1', type: 'field_value', prefix: 'ID-', fieldCode: 'name', format: '' },
+    ]);
+    const record = buildRecord({ name: textField('world') });
+    expect(getId({ condition, record })).toBe('ID-world');
+  });
+
+  test('field_value ルールで対象フィールドが存在しない場合は prefix のみになる', () => {
+    const condition = buildCondition('custom', [
+      { id: 'r1', type: 'field_value', prefix: 'P-', fieldCode: 'missing', format: '' },
+    ]);
+    expect(getId({ condition, record: buildRecord({}) })).toBe('P-');
+  });
+
+  test('constant と field_value を組み合わせて連結する', () => {
+    const condition = buildCondition('custom', [
+      { id: 'r1', type: 'constant', prefix: '', value: 'NO_' },
+      { id: 'r2', type: 'field_value', prefix: '', fieldCode: 'code', format: '' },
+    ]);
+    const record = buildRecord({ code: textField('042') });
+    expect(getId({ condition, record })).toBe('NO_042');
+  });
+
+  test('nanoid ルールは prefix の後ろに空でない値を付与する', () => {
+    const condition = buildCondition('custom', [{ id: 'r1', type: 'nanoid', prefix: 'N-' }]);
+    const id = getId({ condition, record: buildRecord({}) });
+    expect(id.startsWith('N-')).toBe(true);
+    expect(id.length).toBeGreaterThan('N-'.length);
+  });
+
+  test('ルールが空の場合は空文字列を返す', () => {
+    expect(getId({ condition: buildCondition('custom', []), record: buildRecord({}) })).toBe('');
+  });
+});
+
+describe('cn', () => {
+  test('複数のクラス名を半角スペースで連結する', () => {
+    expect(cn('a', 'b')).toBe('a b');
+  });
+
+  test('falsy な値は無視する', () => {
+    expect(cn('a', false, undefined, null, 'b')).toBe('a b');
+  });
+
+  test('条件付きクラスを評価する', () => {
+    const isActive = true;
+    const isDisabled = false;
+    expect(cn('base', isActive && 'active', isDisabled && 'disabled')).toBe('base active');
+  });
+});

--- a/apps/uid/vitest.config.ts
+++ b/apps/uid/vitest.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/apps/uid/vitest.setup.ts
+++ b/apps/uid/vitest.setup.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest';
+
+// `@konomi-app/kintone-utilities` 系のモジュールは読み込み時にグローバルの `kintone`
+// オブジェクトへアクセスするため、テスト環境向けに最小限のスタブを用意する
+vi.stubGlobal('kintone', {
+  app: {
+    getId: () => 1,
+    getLookupTargetAppId: () => null,
+  },
+  mobile: {
+    app: {
+      getId: () => null,
+    },
+  },
+  getLoginUser: () => ({ code: 'taro', name: '田中 太郎', language: 'ja' }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3733,6 +3733,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4))
 
   apps/validation:
     dependencies:


### PR DESCRIPTION
## 概要

テストが全く存在しなかったプラグインの 1 つである **uid** プラグインに対して、ID 生成の中核ロジック（`apps/uid/src/lib/utils.ts`）のユニットテストを追加しました。

> 既存の merged PR #4 で validation プラグインにテストが追加済みのため、本 PR ではまだテストのない uid プラグインを対象としています。

## 追加内容

- **`apps/uid/src/lib/utils.test.ts`** — `getId` / `getRandomValue` / `cn` のユニットテスト（計 18 ケース）
  - `getId`: `nanoid` / `uuid` / `random` / `custom` 各モードと、未知モード時の例外を網羅
  - `custom` モード: `constant` / `field_value` / `nanoid` ルールおよび複数ルールの連結順序、対象フィールド欠落時の挙動を検証
  - `getRandomValue`: base36 文字種・`Math.random` に基づく決定的な値・呼び出しごとの非重複を検証
  - `cn`: クラス名の連結と falsy 値の除外を検証
- **`apps/uid/vitest.config.ts` / `apps/uid/vitest.setup.ts`** — validation プラグインに倣った vitest 設定（`@` エイリアス、グローバル `kintone` スタブ）
- **`apps/uid/package.json`** — `test: vitest run` スクリプトと `vitest` devDependency を追加

## 確認

- `pnpm --filter uid test` → 18 件すべて成功
- `biome check` 通過
- `pnpm install --frozen-lockfile` 通過（lockfile は uid importer への vitest 追加のみの最小差分）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C85kFm1KoJsZN7r7cDZvGj)_